### PR TITLE
refactor: typo fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The second column is the data type (ten in total).
 
 Data values start from the third column. 
 
-Column 3-5 of TYPE_ACCELEROMETER、TYPE_ACCELEROMETER、TYPE_GYROSCOPE、TYPE_ROTATION_VECTOR are SensorEvent.values[0-2] from the callback function onSensorChanged(). Column 6 is SensorEvent.accuracy.
+Column 3-5 of TYPE_ACCELEROMETER、TYPE_MAGNETIC_FIELD、TYPE_GYROSCOPE、TYPE_ROTATION_VECTOR are SensorEvent.values[0-2] from the callback function onSensorChanged(). Column 6 is SensorEvent.accuracy.
 
 Column 3-8 of TYPE_ACCELEROMETER_UNCALIBRATED、TYPE_GYROSCOPE_UNCALIBRATED、TYPE_MAGNETIC_FIELD_UNCALIBRATED are SensorEvent.values[0-5] from the callback function onSensorChanged(). Column 9 is SensorEvent.accuracy.
 


### PR DESCRIPTION
While browsing thorough the readme for extra information regarding the Indoor Location and Navigation competition on Kaggle, I found it confusing seeing **TYPE_ACCELEROMETER** typed twice in the column description section. This is supposed to be **TYPE_MAGNETIC_FIELD**. If the moderators/maintainers would confirm once, this will be a great help.

Thanks.
Mrutyunjay